### PR TITLE
feat: add tenant context resolution

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -17,6 +17,10 @@ doctrine:
         identity_generation_preferences:
             Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform: identity
         auto_mapping: true
+        filters:
+            tenant:
+                class: App\Infrastructure\Persistence\Doctrine\Filter\TenantFilter
+                enabled: false
         mappings:
             Domain:
                 is_bundle: false

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,3 +20,6 @@ services:
     # please note that last definitions always *replace* previous ones
     App\Infrastructure\Monitoring\RequestIdProcessor:
         tags: ['monolog.processor']
+    App\Shared\Tenant\TenantContext:
+        public: true
+        shared: false

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -1,0 +1,17 @@
+# Multi-Tenant Context
+
+This application isolates data by tenant. Each HTTP request resolves a tenant identifier using the following order:
+
+1. JWT `tenant_id` claim
+2. Custom domain mapping
+3. Subdomain mapping
+4. `X-API-Key` header
+
+If none match, the request is rejected with `TenantNotFound` (400).
+
+The resolved tenant id is exposed through the `TenantContext` service and request attributes. Database isolation is enforced by:
+
+* Setting `app.tenant_id` on the PostgreSQL session.
+* Enabling the Doctrine `TenantFilter` with the current tenant id.
+
+API responses include `meta.tenant_id` in the unified response envelope.

--- a/src/Infrastructure/API/ProbeController.php
+++ b/src/Infrastructure/API/ProbeController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Infrastructure\API;
+
+use App\Shared\Tenant\TenantContext;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ProbeController
+{
+    public function __construct(private TenantContext $context)
+    {
+    }
+
+    #[Route('/probe', name: 'tenant_probe')]
+    public function __invoke(): JsonResponse
+    {
+        $this->context->get();
+
+        return new JsonResponse([
+            'status' => 'ok',
+            'data' => null,
+            'meta' => [],
+            'errors' => [],
+        ]);
+    }
+}

--- a/src/Infrastructure/API/ResponseEnvelopeSubscriber.php
+++ b/src/Infrastructure/API/ResponseEnvelopeSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Infrastructure\API;
+
+use App\Shared\Tenant\TenantContext;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+#[AsEventListener(event: KernelEvents::RESPONSE)]
+final class ResponseEnvelopeSubscriber
+{
+    public function __construct(private TenantContext $context)
+    {
+    }
+
+    public function __invoke(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $content = $response->getContent();
+        if (!$content) {
+            return;
+        }
+        $data = json_decode($content, true);
+        if (!is_array($data)) {
+            return;
+        }
+        if (!isset($data['meta']) || !is_array($data['meta'])) {
+            $data['meta'] = [];
+        }
+        if ($this->context->has()) {
+            $data['meta']['tenant_id'] = $this->context->get();
+        }
+        $response->setContent(json_encode($data));
+    }
+}

--- a/src/Infrastructure/Http/TenantContextListener.php
+++ b/src/Infrastructure/Http/TenantContextListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Infrastructure\Http;
+
+use App\Shared\Tenant\TenantContext;
+use App\Shared\Tenant\TenantResolver;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 256)]
+final class TenantContextListener
+{
+    public function __construct(
+        private TenantResolver $resolver,
+        private TenantContext $context,
+        private EntityManagerInterface $em,
+        private Connection $db,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if ($this->context->has()) {
+            $tenantId = $this->context->get();
+        } else {
+            $tenantId = $this->resolver->resolve($request);
+            if (!$tenantId) {
+                throw new \DomainException('TenantNotFound');
+            }
+            $this->context->set($tenantId);
+            $request->attributes->set('tenant_id', $tenantId);
+        }
+
+        $this->db->executeStatement('SET app.tenant_id = :tenant', ['tenant' => $tenantId]);
+        $this->em->getFilters()->enable('tenant')->setParameter('tenant_id', $tenantId);
+
+        $this->logger->info('Resolved tenant', ['tenant_id' => $tenantId]);
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Filter/TenantFilter.php
+++ b/src/Infrastructure/Persistence/Doctrine/Filter/TenantFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Infrastructure\Persistence\Doctrine\Filter;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+
+final class TenantFilter extends SQLFilter
+{
+    public function addFilterConstraint(ClassMetadata $targetEntity, string $targetTableAlias): string
+    {
+        if (!$targetEntity->hasField('tenantId') && !$targetEntity->hasField('tenant_id')) {
+            return '';
+        }
+
+        return sprintf('%s.tenant_id = %s', $targetTableAlias, $this->getParameter('tenant_id'));
+    }
+}

--- a/src/Shared/Tenant/ApiKeyRepository.php
+++ b/src/Shared/Tenant/ApiKeyRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+interface ApiKeyRepository
+{
+    public function tenantIdForKey(string $key): ?string;
+}

--- a/src/Shared/Tenant/JwtDecoder.php
+++ b/src/Shared/Tenant/JwtDecoder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+interface JwtDecoder
+{
+    /**
+     * @param string $header Authorization header value
+     *
+     * @return array<string,mixed>
+     */
+    public function decodeFromHeader(string $header): array;
+}

--- a/src/Shared/Tenant/NullApiKeyRepository.php
+++ b/src/Shared/Tenant/NullApiKeyRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+final class NullApiKeyRepository implements ApiKeyRepository
+{
+    public function tenantIdForKey(string $key): ?string
+    {
+        return null;
+    }
+}

--- a/src/Shared/Tenant/NullJwtDecoder.php
+++ b/src/Shared/Tenant/NullJwtDecoder.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+final class NullJwtDecoder implements JwtDecoder
+{
+    public function decodeFromHeader(string $header): array
+    {
+        return [];
+    }
+}

--- a/src/Shared/Tenant/NullTenantRepository.php
+++ b/src/Shared/Tenant/NullTenantRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+use App\Domain\Tenant\Entity\Tenant;
+
+final class NullTenantRepository implements TenantRepository
+{
+    public function findByCustomDomain(string $domain): ?Tenant
+    {
+        return null;
+    }
+
+    public function findBySlug(string $slug): ?Tenant
+    {
+        return null;
+    }
+}

--- a/src/Shared/Tenant/TenantContext.php
+++ b/src/Shared/Tenant/TenantContext.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+final class TenantContext
+{
+    public function __construct(private ?string $tenantId = null)
+    {
+    }
+
+    public function set(string $tenantId): void
+    {
+        $this->tenantId = $tenantId;
+    }
+
+    public function get(): string
+    {
+        if (!$this->tenantId) {
+            throw new \LogicException('Tenant not resolved');
+        }
+
+        return $this->tenantId;
+    }
+
+    public function has(): bool
+    {
+        return (bool) $this->tenantId;
+    }
+}

--- a/src/Shared/Tenant/TenantRepository.php
+++ b/src/Shared/Tenant/TenantRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+use App\Domain\Tenant\Entity\Tenant;
+
+interface TenantRepository
+{
+    public function findByCustomDomain(string $domain): ?Tenant;
+
+    public function findBySlug(string $slug): ?Tenant;
+}

--- a/src/Shared/Tenant/TenantResolver.php
+++ b/src/Shared/Tenant/TenantResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Shared\Tenant;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class TenantResolver
+{
+    public function __construct(
+        private TenantRepository $tenants,
+        private ApiKeyRepository $apiKeys,
+        private JwtDecoder $jwt
+    ) {
+    }
+
+    public function resolve(Request $req): ?string
+    {
+        // 1) JWT claim
+        if ($jwt = $req->headers->get('Authorization')) {
+            $claims = $this->jwt->decodeFromHeader($jwt);
+            if (!empty($claims['tenant_id'])) {
+                return (string) $claims['tenant_id'];
+            }
+        }
+
+        // 2) custom domain
+        $host = $req->getHost();
+        if ($tenant = $this->tenants->findByCustomDomain($host)) {
+            return (string) $tenant->getId();
+        }
+
+        // 3) subdomain
+        if (preg_match('/^(?<slug>[^.]+)\./', $host, $m)) {
+            if ($tenant = $this->tenants->findBySlug($m['slug'])) {
+                return (string) $tenant->getId();
+            }
+        }
+
+        // 4) X-API-Key
+        if ($key = $req->headers->get('X-API-Key')) {
+            if ($tenantId = $this->apiKeys->tenantIdForKey($key)) {
+                return $tenantId;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Functional/TenantContextListenerTest.php
+++ b/tests/Functional/TenantContextListenerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Tests\Functional;
+
+use App\Infrastructure\Http\TenantContextListener;
+use App\Infrastructure\API\ResponseEnvelopeSubscriber;
+use App\Infrastructure\Persistence\Doctrine\Filter\TenantFilter;
+use App\Shared\Tenant\TenantContext;
+use App\Shared\Tenant\TenantResolver;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\FilterCollection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Psr\Log\NullLogger;
+
+class TenantContextListenerTest extends TestCase
+{
+    private function handleRequest(string $tenantId, Request $request): array
+    {
+        $context = new TenantContext();
+        $tenantRepo = $this->createMock(\App\Shared\Tenant\TenantRepository::class);
+        $apiRepo = $this->createMock(\App\Shared\Tenant\ApiKeyRepository::class);
+        $jwt = $this->createMock(\App\Shared\Tenant\JwtDecoder::class);
+        $jwt->method('decodeFromHeader')->willReturn(['tenant_id' => $tenantId]);
+        $resolver = new TenantResolver($tenantRepo, $apiRepo, $jwt);
+
+        $conn = $this->createMock(Connection::class);
+        $conn->expects($this->once())
+            ->method('executeStatement')
+            ->with('SET app.tenant_id = :tenant', ['tenant' => $tenantId]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $filters = $this->createMock(FilterCollection::class);
+        $tenantFilter = new TenantFilter($em);
+        $filters->expects($this->once())->method('enable')->with('tenant')->willReturn($tenantFilter);
+        $em->method('getFilters')->willReturn($filters);
+        $em->method('getConnection')->willReturn($conn);
+
+        $listener = new TenantContextListener($resolver, $context, $em, $conn, new NullLogger());
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+        $listener($event);
+
+        return [$context, $tenantFilter];
+    }
+
+    public function test_tenant_context_and_response_envelope(): void
+    {
+        $request = new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer token']);
+        [$context, $filter] = $this->handleRequest('tenantA', $request);
+
+        self::assertTrue($context->has());
+        self::assertSame('tenantA', $context->get());
+
+        $response = new JsonResponse(['status' => 'ok', 'data' => null, 'meta' => [], 'errors' => []]);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $subscriber = new ResponseEnvelopeSubscriber($context);
+        $subscriber($event);
+
+        $data = json_decode($response->getContent(), true);
+        self::assertSame('tenantA', $data['meta']['tenant_id']);
+    }
+
+    public function test_missing_tenant_throws_exception(): void
+    {
+        $request = new Request();
+        $context = new TenantContext();
+        $tenantRepo = $this->createMock(\App\Shared\Tenant\TenantRepository::class);
+        $apiRepo = $this->createMock(\App\Shared\Tenant\ApiKeyRepository::class);
+        $jwt = $this->createMock(\App\Shared\Tenant\JwtDecoder::class);
+        $jwt->method('decodeFromHeader')->willReturn([]);
+        $resolver = new TenantResolver($tenantRepo, $apiRepo, $jwt);
+        $conn = $this->createMock(Connection::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $listener = new TenantContextListener($resolver, $context, $em, $conn, new NullLogger());
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(\DomainException::class);
+        $listener($event);
+    }
+}

--- a/tests/Shared/Tenant/TenantResolverTest.php
+++ b/tests/Shared/Tenant/TenantResolverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests\Shared\Tenant;
+
+use App\Domain\Tenant\Entity\Tenant;
+use App\Shared\Tenant\ApiKeyRepository;
+use App\Shared\Tenant\JwtDecoder;
+use App\Shared\Tenant\TenantRepository;
+use App\Shared\Tenant\TenantResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Uid\Uuid;
+
+class TenantResolverTest extends TestCase
+{
+    public function test_resolves_from_jwt(): void
+    {
+        $tenantRepo = $this->createMock(TenantRepository::class);
+        $apiKeyRepo = $this->createMock(ApiKeyRepository::class);
+        $jwt = $this->createMock(JwtDecoder::class);
+        $jwt->method('decodeFromHeader')->with('Bearer token')->willReturn(['tenant_id' => 't1']);
+
+        $resolver = new TenantResolver($tenantRepo, $apiKeyRepo, $jwt);
+        $req = Request::create('/', server: ['HTTP_AUTHORIZATION' => 'Bearer token']);
+
+        self::assertSame('t1', $resolver->resolve($req));
+    }
+
+    public function test_resolves_from_custom_domain(): void
+    {
+        $tenant = $this->createConfiguredMock(Tenant::class, ['getId' => Uuid::fromString('00000000-0000-0000-0000-000000000002')]);
+        $tenantRepo = $this->createMock(TenantRepository::class);
+        $tenantRepo->method('findByCustomDomain')->with('foo.com')->willReturn($tenant);
+        $apiKeyRepo = $this->createMock(ApiKeyRepository::class);
+        $jwt = $this->createMock(JwtDecoder::class);
+
+        $resolver = new TenantResolver($tenantRepo, $apiKeyRepo, $jwt);
+        $req = Request::create('https://foo.com');
+
+        self::assertSame('00000000-0000-0000-0000-000000000002', $resolver->resolve($req));
+    }
+
+    public function test_resolves_from_subdomain(): void
+    {
+        $tenant = $this->createConfiguredMock(Tenant::class, ['getId' => Uuid::fromString('00000000-0000-0000-0000-000000000003')]);
+        $tenantRepo = $this->createMock(TenantRepository::class);
+        $tenantRepo->method('findBySlug')->with('bar')->willReturn($tenant);
+        $apiKeyRepo = $this->createMock(ApiKeyRepository::class);
+        $jwt = $this->createMock(JwtDecoder::class);
+
+        $resolver = new TenantResolver($tenantRepo, $apiKeyRepo, $jwt);
+        $req = Request::create('https://bar.example.com');
+
+        self::assertSame('00000000-0000-0000-0000-000000000003', $resolver->resolve($req));
+    }
+
+    public function test_resolves_from_api_key(): void
+    {
+        $tenantRepo = $this->createMock(TenantRepository::class);
+        $apiKeyRepo = $this->createMock(ApiKeyRepository::class);
+        $apiKeyRepo->method('tenantIdForKey')->with('abc')->willReturn('t4');
+        $jwt = $this->createMock(JwtDecoder::class);
+
+        $resolver = new TenantResolver($tenantRepo, $apiKeyRepo, $jwt);
+        $req = Request::create('/', server: ['HTTP_X_API_KEY' => 'abc']);
+
+        self::assertSame('t4', $resolver->resolve($req));
+    }
+
+    public function test_returns_null_when_no_source_matches(): void
+    {
+        $tenantRepo = $this->createMock(TenantRepository::class);
+        $apiKeyRepo = $this->createMock(ApiKeyRepository::class);
+        $jwt = $this->createMock(JwtDecoder::class);
+
+        $resolver = new TenantResolver($tenantRepo, $apiKeyRepo, $jwt);
+        $req = Request::create('/');
+
+        self::assertNull($resolver->resolve($req));
+    }
+}


### PR DESCRIPTION
## Summary
- resolve tenant per request and enforce isolation via DB session and Doctrine filter
- attach tenant_id to API responses
- document tenancy model and cover resolver and listener with tests

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17ca301e08333b3d3fd974383b9ef