### PR TITLE
feat: add tenant-aware RBAC and ABAC policies

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -2,6 +2,12 @@ security:
   password_hashers:
     Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 
+  role_hierarchy:
+    ROLE_ADMIN:       ['ROLE_MANAGER']
+    ROLE_MANAGER:     ['ROLE_CUSTOMER']
+    ROLE_CUSTOMER:    ['ROLE_GUEST']
+    ROLE_GUEST:       []
+
   providers:
     app_in_memory:
       memory:

--- a/config/packages/security_policies.yaml
+++ b/config/packages/security_policies.yaml
@@ -1,0 +1,4 @@
+parameters:
+    security.policies:
+        order.view: "is_granted('ROLE_MANAGER') or (user.id == subject.customerId)"
+        product.write: "is_granted('ROLE_MANAGER') and tenant(feature('catalog_write'))"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,5 +35,12 @@ services:
         decoration_on_invalid: ignore
         arguments: ['@?App\\Infrastructure\\API\\Pagination\\State\\CursorCollectionProvider.inner']
 
+    App\Infrastructure\Security\PolicyEvaluator:
+        arguments:
+            $policies: '%security.policies%'
+
+    App\Shared\Feature\FeatureFlagService:
+        public: true
+
 # App\Infrastructure\Security\JWTCreatedListener:
 #   tags: [ { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated } ]

--- a/docs/adr/0001-rbac-abac-starter.md
+++ b/docs/adr/0001-rbac-abac-starter.md
@@ -1,0 +1,15 @@
+# 0001-rbac-abac-starter
+
+## Context
+We need foundational role and attribute based access control with multi-tenant awareness. Policies must be centrally managed and evaluated consistently across REST and GraphQL endpoints.
+
+## Decision
+- Policies are declared in `config/packages/security_policies.yaml` and loaded into a cacheable `PolicyEvaluator` that uses Symfony ExpressionLanguage.
+- Expressions expose `is_granted()`, `user`, `subject`, `tenant()` and `feature(name)` helpers.
+- Custom voters invoke `PolicyEvaluator` and short-circuit when tenant context does not match the resource.
+- API Platform operations delegate to these voters via `security` expressions.
+
+## Consequences
+- Adding a new policy requires updating the YAML file, wiring a voter, and referencing it via `is_granted('policy.key', object)` on resources or operations.
+- `tenant()` derives the current tenant from `TenantContext`; `feature(name)` checks feature flags through `FeatureFlagService`.
+- The pattern scales to future helpers (e.g. `segment()`, `timeOfDay()`) and more policies.

--- a/src/Domain/Catalog/Product.php
+++ b/src/Domain/Catalog/Product.php
@@ -4,12 +4,24 @@ declare(strict_types=1);
 
 namespace App\Domain\Catalog;
 
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use App\Infrastructure\API\State\ProductProcessor;
 use Symfony\Component\Uid\Uuid;
 
 /**
  * Minimal Product entity stub.
  * TODO: Expand with persistence mapping and additional fields.
  */
+#[ApiResource(operations: [
+    new Post(security: "is_granted('product.write', object ?? null)", processor: ProductProcessor::class),
+    new Put(security: "is_granted('product.write', object ?? null)", processor: ProductProcessor::class),
+    new Patch(security: "is_granted('product.write', object ?? null)", processor: ProductProcessor::class),
+    new Delete(security: "is_granted('product.write', object ?? null)", processor: ProductProcessor::class),
+])]
 final class Product
 {
     public function __construct(
@@ -18,6 +30,7 @@ final class Product
         private string $name,
         private int $priceCents,
         private string $currency,
+        public ?string $tenantId = null,
     ) {
     }
 

--- a/src/Domain/Order/Order.php
+++ b/src/Domain/Order/Order.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use App\Infrastructure\API\State\OrderProvider;
+use Symfony\Component\Uid\Uuid;
+
+#[ApiResource(provider: OrderProvider::class, operations: [
+    new Get(security: "is_granted('order.view', object)"),
+])]
+final class Order
+{
+    public function __construct(
+        private Uuid $id,
+        public string $customerId,
+        public string $tenantId,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}
+

--- a/src/Infrastructure/API/OrderController.php
+++ b/src/Infrastructure/API/OrderController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\API;
+
+use App\Domain\Order\Order;
+use App\Infrastructure\API\State\OrderProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+final class OrderController extends AbstractController
+{
+    #[Route('/api/orders/{id}', methods: ['GET'])]
+    public function __invoke(string $id): JsonResponse
+    {
+        $order = new Order(Uuid::fromString($id), OrderProvider::CUSTOMER_ID, OrderProvider::TENANT_ID);
+        $this->denyAccessUnlessGranted('order.view', $order);
+
+        return new JsonResponse(['id' => $order->getId()->toRfc4122()]);
+    }
+}
+

--- a/src/Infrastructure/API/ProductController.php
+++ b/src/Infrastructure/API/ProductController.php
@@ -4,15 +4,31 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\API;
 
+use App\Domain\Catalog\Product;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
 
-final class ProductController
+final class ProductController extends AbstractController
 {
-    #[Route('/products', methods: ['GET'])]
-    public function __invoke(): array
+    #[Route('/api/products', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
     {
-        return [
-            ['id' => 1, 'name' => 'Sample']
-        ];
+        $data = $request->toArray();
+        $product = new Product(
+            Uuid::fromString($data['id']),
+            $data['slug'],
+            $data['name'],
+            (int) $data['priceCents'],
+            $data['currency'],
+            $data['tenantId'] ?? null,
+        );
+
+        $this->denyAccessUnlessGranted('product.write', $product);
+
+        return new JsonResponse(['id' => $product->getId()->toRfc4122()], 201);
     }
 }
+

--- a/src/Infrastructure/API/State/OrderProvider.php
+++ b/src/Infrastructure/API/State/OrderProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\API\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Domain\Order\Order;
+use Symfony\Component\Uid\Uuid;
+
+final class OrderProvider implements ProviderInterface
+{
+    public const CUSTOMER_ID = '00000000-0000-0000-8000-000000000001';
+    public const TENANT_ID = '11111111-1111-1111-8111-111111111111';
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): Order
+    {
+        $id = Uuid::fromString((string) ($uriVariables['id'] ?? Uuid::v4()->toRfc4122()));
+
+        return new Order($id, self::CUSTOMER_ID, self::TENANT_ID);
+    }
+}
+

--- a/src/Infrastructure/API/State/ProductProcessor.php
+++ b/src/Infrastructure/API/State/ProductProcessor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\API\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+
+final class ProductProcessor implements ProcessorInterface
+{
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        return $data;
+    }
+}
+

--- a/src/Infrastructure/Security/Expression/ExpressionLanguageFactory.php
+++ b/src/Infrastructure/Security/Expression/ExpressionLanguageFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security\Expression;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Uid\Uuid;
+
+final class ExpressionLanguageFactory
+{
+    public function create(): ExpressionLanguage
+    {
+        $el = new ExpressionLanguage();
+
+        $el->addFunction(new ExpressionFunction(
+            'is_granted',
+            fn($attribute, $subject = 'null') => sprintf('$auth_checker->isGranted(%s, %s)', $attribute, $subject),
+            fn(array $variables, $attribute, $subject = null) => $variables['auth_checker']->isGranted($attribute, $subject)
+        ));
+
+        $el->addFunction(new ExpressionFunction(
+            'tenant',
+            fn($expr = 'true') => sprintf('$tenant_context->has() ? %s : false', $expr),
+            fn(array $variables, $expr = true) => $variables['tenant_context']->has() ? $expr : false
+        ));
+
+        $el->addFunction(new ExpressionFunction(
+            'feature',
+            fn($name) => sprintf('$tenant_context->has() ? $feature_flags->enabled(%s, \\Symfony\\Component\\Uid\\Uuid::fromString($tenant_context->get()->toString())) : false', $name),
+            fn(array $variables, $name) => $variables['tenant_context']->has()
+                ? $variables['feature_flags']->enabled($name, Uuid::fromString($variables['tenant_context']->get()->toString()))
+                : false
+        ));
+
+        return $el;
+    }
+}
+

--- a/src/Infrastructure/Security/PolicyEvaluator.php
+++ b/src/Infrastructure/Security/PolicyEvaluator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security;
+
+use App\Infrastructure\Security\Expression\ExpressionLanguageFactory;
+use App\Shared\Feature\FeatureFlagService;
+use App\Shared\Tenant\TenantContext;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ParsedExpression;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+final class PolicyEvaluator
+{
+    private array $compiled = [];
+
+    public function __construct(
+        array $policies,
+        private AuthorizationCheckerInterface $authChecker,
+        private TenantContext $tenantContext,
+        private FeatureFlagService $featureFlags,
+        ExpressionLanguageFactory $factory,
+    ) {
+        $language = $factory->create();
+        foreach ($policies as $key => $expression) {
+            $this->compiled[$key] = $language->parse($expression, ['user', 'subject', 'auth_checker', 'tenant_context', 'feature_flags']);
+        }
+        $this->language = $language;
+    }
+
+    public function decide(string $policy, ?object $user = null, ?object $subject = null): bool
+    {
+        if (!isset($this->compiled[$policy])) {
+            throw new \InvalidArgumentException(sprintf('Unknown policy "%s"', $policy));
+        }
+
+        /** @var ParsedExpression $expr */
+        $expr = $this->compiled[$policy];
+
+        return (bool) $this->language->evaluate($expr, [
+            'user' => $user,
+            'subject' => $subject,
+            'auth_checker' => $this->authChecker,
+            'tenant_context' => $this->tenantContext,
+            'feature_flags' => $this->featureFlags,
+        ]);
+    }
+
+    private ExpressionLanguage $language;
+}
+

--- a/src/Infrastructure/Security/User.php
+++ b/src/Infrastructure/Security/User.php
@@ -7,14 +7,22 @@ namespace App\Infrastructure\Security;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * Placeholder user model for future authentication implementation.
- */
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
+    public function __construct(
+        public string $id,
+        private array $roles = []
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
     public function getRoles(): array
     {
-        return [];
+        return $this->roles;
     }
 
     public function getPassword(): ?string
@@ -24,11 +32,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function getUserIdentifier(): string
     {
-        return 'anon';
+        return $this->id;
     }
 
     public function eraseCredentials(): void
     {
-        // noop
     }
 }
+

--- a/src/Infrastructure/Security/UserProvider.php
+++ b/src/Infrastructure/Security/UserProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Security;
 
+use Lexik\Bundle\JWTAuthenticationBundle\Security\User\PayloadAwareUserProviderInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -13,11 +14,22 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  *
  * @implements UserProviderInterface<User>
  */
-class UserProvider implements UserProviderInterface
+/**
+ * @implements UserProviderInterface<User>
+ */
+class UserProvider implements UserProviderInterface, PayloadAwareUserProviderInterface
 {
     public function loadUserByIdentifier(string $identifier): UserInterface
     {
-        return new User();
+        return new User($identifier);
+    }
+
+    public function loadUserByIdentifierAndPayload(string $identifier, array $payload): UserInterface
+    {
+        $id = $payload['id'] ?? $identifier;
+        $roles = $payload['roles'] ?? [];
+
+        return new User((string) $id, $roles);
     }
 
     public function refreshUser(UserInterface $user): UserInterface

--- a/src/Infrastructure/Security/Voter/OrderVoter.php
+++ b/src/Infrastructure/Security/Voter/OrderVoter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security\Voter;
+
+use App\Domain\Order\Order;
+use App\Infrastructure\Security\PolicyEvaluator;
+use App\Shared\Tenant\TenantContext;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+final class OrderVoter extends Voter
+{
+    public const VIEW = 'order.view';
+
+    public function __construct(
+        private PolicyEvaluator $evaluator,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return self::VIEW === $attribute && $subject instanceof Order;
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        if (!$subject instanceof Order) {
+            return false;
+        }
+
+        if ($this->tenantContext->has() && $subject->tenantId !== $this->tenantContext->get()->toString()) {
+            return false;
+        }
+
+        $user = $token->getUser();
+        if (!is_object($user)) {
+            return false;
+        }
+
+        return $this->evaluator->decide(self::VIEW, $user, $subject);
+    }
+}
+

--- a/src/Infrastructure/Security/Voter/ProductVoter.php
+++ b/src/Infrastructure/Security/Voter/ProductVoter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security\Voter;
+
+use App\Domain\Catalog\Product;
+use App\Infrastructure\Security\PolicyEvaluator;
+use App\Shared\Tenant\TenantContext;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+final class ProductVoter extends Voter
+{
+    public const WRITE = 'product.write';
+
+    public function __construct(
+        private PolicyEvaluator $evaluator,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return self::WRITE === $attribute && (null === $subject || $subject instanceof Product);
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        if ($subject instanceof Product && $this->tenantContext->has() && $subject->tenantId !== $this->tenantContext->get()->toString()) {
+            return false;
+        }
+
+        $user = $token->getUser();
+        if (!is_object($user)) {
+            return false;
+        }
+
+        return $this->evaluator->decide(self::WRITE, $user, $subject);
+    }
+}
+

--- a/src/Shared/Feature/FeatureFlagService.php
+++ b/src/Shared/Feature/FeatureFlagService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Feature;
+
+use Symfony\Component\Uid\Uuid;
+
+final class FeatureFlagService
+{
+    /** @var array<string, array<string,bool>> */
+    private array $flags = [];
+
+    public function enabled(string $name, Uuid $tenantId): bool
+    {
+        return $this->flags[$tenantId->toRfc4122()][$name] ?? false;
+    }
+
+    public function set(Uuid $tenantId, string $name, bool $enabled): void
+    {
+        $this->flags[$tenantId->toRfc4122()][$name] = $enabled;
+    }
+}
+

--- a/tests/Functional/Api/OrderSecurityTest.php
+++ b/tests/Functional/Api/OrderSecurityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Api;
+
+use App\Infrastructure\API\State\OrderProvider;
+use App\Tests\Functional\ApiTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class OrderSecurityTest extends ApiTestCase
+{
+    public function testManagerCanViewOrder(): void
+    {
+        $client = $this->createClientWithManualToken([
+            'id' => 'manager',
+            'username' => 'manager',
+            'roles' => ['ROLE_MANAGER'],
+            'tenant_id' => OrderProvider::TENANT_ID,
+        ]);
+
+        $dispatcher = $client->getContainer()->get('event_dispatcher');
+        $listener = $client->getContainer()->get(\App\Infrastructure\Persistence\Doctrine\SetTenantRlsSessionListener::class);
+        $dispatcher->removeListener('kernel.request', [$listener, '__invoke']);
+
+        $client->request('GET', '/api/orders/' . Uuid::v4()->toRfc4122());
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    public function testOtherCustomerDenied(): void
+    {
+        $client = $this->createClientWithManualToken([
+            'id' => 'customer-2',
+            'username' => 'customer-2',
+            'roles' => ['ROLE_CUSTOMER'],
+            'tenant_id' => OrderProvider::TENANT_ID,
+        ]);
+
+        $dispatcher = $client->getContainer()->get('event_dispatcher');
+        $listener = $client->getContainer()->get(\App\Infrastructure\Persistence\Doctrine\SetTenantRlsSessionListener::class);
+        $dispatcher->removeListener('kernel.request', [$listener, '__invoke']);
+
+        $client->request('GET', '/api/orders/' . Uuid::v4()->toRfc4122());
+        self::assertResponseStatusCodeSame(403);
+    }
+}
+

--- a/tests/Functional/Api/ProductSecurityTest.php
+++ b/tests/Functional/Api/ProductSecurityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Api;
+
+use App\Shared\Feature\FeatureFlagService;
+use App\Tests\Functional\ApiTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ProductSecurityTest extends ApiTestCase
+{
+    public function testPostDeniedWhenFeatureDisabled(): void
+    {
+        $tenantId = Uuid::v4();
+        $client = $this->createClientWithManualToken([
+            'id' => 'manager',
+            'username' => 'manager',
+            'roles' => ['ROLE_MANAGER'],
+            'tenant_id' => $tenantId->toRfc4122(),
+        ]);
+        $dispatcher = $client->getContainer()->get('event_dispatcher');
+        $listener = $client->getContainer()->get(\App\Infrastructure\Persistence\Doctrine\SetTenantRlsSessionListener::class);
+        $dispatcher->removeListener('kernel.request', [$listener, '__invoke']);
+
+        $client->getContainer()->get(\App\Shared\Tenant\TenantContext::class)
+            ->set(new \App\Shared\Tenant\TenantId($tenantId->toRfc4122()));
+
+        $client->request('POST', '/api/products', ['json' => [
+            'id' => Uuid::v4()->toRfc4122(),
+            'slug' => 's',
+            'name' => 'n',
+            'priceCents' => 100,
+            'currency' => 'USD',
+            'tenantId' => $tenantId->toRfc4122(),
+        ]]);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testPostAllowedWhenFeatureEnabled(): void
+    {
+        $tenantId = Uuid::v4();
+        $client = $this->createClientWithManualToken([
+            'id' => 'manager',
+            'username' => 'manager',
+            'roles' => ['ROLE_MANAGER'],
+            'tenant_id' => $tenantId->toRfc4122(),
+        ]);
+        $dispatcher = $client->getContainer()->get('event_dispatcher');
+        $listener = $client->getContainer()->get(\App\Infrastructure\Persistence\Doctrine\SetTenantRlsSessionListener::class);
+        $dispatcher->removeListener('kernel.request', [$listener, '__invoke']);
+
+        $client->getContainer()->get(\App\Shared\Tenant\TenantContext::class)
+            ->set(new \App\Shared\Tenant\TenantId($tenantId->toRfc4122()));
+
+        self::getContainer()->get(FeatureFlagService::class)->set($tenantId, 'catalog_write', true);
+
+        $client->request('POST', '/api/products', ['json' => [
+            'id' => Uuid::v4()->toRfc4122(),
+            'slug' => 's',
+            'name' => 'n',
+            'priceCents' => 100,
+            'currency' => 'USD',
+            'tenantId' => $tenantId->toRfc4122(),
+        ]]);
+        self::assertResponseStatusCodeSame(201);
+    }
+}
+

--- a/tests/Unit/Security/PolicyEvaluatorTest.php
+++ b/tests/Unit/Security/PolicyEvaluatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Infrastructure\Security\Expression\ExpressionLanguageFactory;
+use App\Infrastructure\Security\PolicyEvaluator;
+use App\Shared\Feature\FeatureFlagService;
+use App\Shared\Tenant\TenantContext;
+use App\Shared\Tenant\TenantId;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class PolicyEvaluatorTest extends TestCase
+{
+    private function createEvaluator(array $roles, bool $featureEnabled): PolicyEvaluator
+    {
+        $auth = new class($roles) implements AuthorizationCheckerInterface {
+            public function __construct(private array $roles) {}
+            public function isGranted($attribute, $subject = null): bool
+            {
+                return in_array($attribute, $this->roles, true);
+            }
+        };
+
+        $tenantId = new TenantId(Uuid::v4()->toRfc4122());
+        $tenantContext = new TenantContext($tenantId);
+        $flags = new FeatureFlagService();
+        $flags->set(Uuid::fromString($tenantId->toString()), 'catalog_write', $featureEnabled);
+
+        return new PolicyEvaluator(
+            [
+                'order.view' => "is_granted('ROLE_MANAGER') or (user.id == subject.customerId)",
+                'product.write' => "is_granted('ROLE_MANAGER') and tenant(feature('catalog_write'))",
+            ],
+            $auth,
+            $tenantContext,
+            $flags,
+            new ExpressionLanguageFactory(),
+        );
+    }
+
+    public function testOrderViewPolicy(): void
+    {
+        $evaluator = $this->createEvaluator(['ROLE_MANAGER'], true);
+        $user = (object) ['id' => 'u1'];
+        $order = (object) ['customerId' => 'u2', 'tenantId' => 't'];
+        self::assertTrue($evaluator->decide('order.view', $user, $order));
+
+        $evaluator = $this->createEvaluator([], true);
+        $user2 = (object) ['id' => 'cust'];
+        $order2 = (object) ['customerId' => 'cust', 'tenantId' => 't'];
+        self::assertTrue($evaluator->decide('order.view', $user2, $order2));
+    }
+
+    public function testProductWritePolicy(): void
+    {
+        $evaluator = $this->createEvaluator(['ROLE_MANAGER'], true);
+        $user = (object) ['id' => 'manager'];
+        self::assertTrue($evaluator->decide('product.write', $user, null));
+
+        $evaluator = $this->createEvaluator(['ROLE_MANAGER'], false);
+        self::assertFalse($evaluator->decide('product.write', $user, null));
+    }
+}
+

--- a/tests/Unit/Security/Voter/OrderVoterTest.php
+++ b/tests/Unit/Security/Voter/OrderVoterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security\Voter;
+
+use App\Domain\Order\Order;
+use App\Infrastructure\Security\Expression\ExpressionLanguageFactory;
+use App\Infrastructure\Security\PolicyEvaluator;
+use App\Infrastructure\Security\Voter\OrderVoter;
+use App\Shared\Feature\FeatureFlagService;
+use App\Shared\Tenant\TenantContext;
+use App\Shared\Tenant\TenantId;
+use App\Infrastructure\Security\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class OrderVoterTest extends TestCase
+{
+    private function createEvaluator(array $roles, TenantContext $tenantContext): PolicyEvaluator
+    {
+        $auth = new class($roles) implements AuthorizationCheckerInterface {
+            public function __construct(private array $roles) {}
+            public function isGranted($attribute, $subject = null): bool
+            {
+                return in_array($attribute, $this->roles, true);
+            }
+        };
+        $flags = new FeatureFlagService();
+        $flags->set(Uuid::fromString($tenantContext->get()->toString()), 'catalog_write', true);
+
+        return new PolicyEvaluator([
+            'order.view' => "is_granted('ROLE_MANAGER') or (user.id == subject.customerId)",
+            'product.write' => "is_granted('ROLE_MANAGER') and tenant(feature('catalog_write'))",
+        ], $auth, $tenantContext, $flags, new ExpressionLanguageFactory());
+    }
+
+    public function testManagerCanViewAnyOrder(): void
+    {
+        $tenantId = new TenantId(Uuid::v4()->toRfc4122());
+        $tenantContext = new TenantContext($tenantId);
+        $evaluator = $this->createEvaluator(['ROLE_MANAGER'], $tenantContext);
+        $voter = new OrderVoter($evaluator, $tenantContext);
+
+        $order = new Order(Uuid::v4(), 'cust', $tenantId->toString());
+        $user = new User('manager');
+        $token = $this->createConfiguredMock(TokenInterface::class, ['getUser' => $user]);
+        $result = $voter->vote($token, $order, ['order.view']);
+        self::assertSame(OrderVoter::ACCESS_GRANTED, $result);
+    }
+
+    public function testCustomerCanViewOwnOrderOnly(): void
+    {
+        $tenantId = new TenantId(Uuid::v4()->toRfc4122());
+        $tenantContext = new TenantContext($tenantId);
+        $evaluator = $this->createEvaluator([], $tenantContext);
+        $voter = new OrderVoter($evaluator, $tenantContext);
+
+        $order = new Order(Uuid::v4(), 'customer1', $tenantId->toString());
+        $user = new User('customer1');
+        $token = $this->createConfiguredMock(TokenInterface::class, ['getUser' => $user]);
+        self::assertSame(OrderVoter::ACCESS_GRANTED, $voter->vote($token, $order, ['order.view']));
+
+        $otherUser = new User('customer2');
+        $token2 = $this->createConfiguredMock(TokenInterface::class, ['getUser' => $otherUser]);
+        self::assertSame(OrderVoter::ACCESS_DENIED, $voter->vote($token2, $order, ['order.view']));
+    }
+
+    public function testCrossTenantDenied(): void
+    {
+        $tenantId = new TenantId(Uuid::v4()->toRfc4122());
+        $tenantContext = new TenantContext($tenantId);
+        $evaluator = $this->createEvaluator(['ROLE_MANAGER'], $tenantContext);
+        $voter = new OrderVoter($evaluator, $tenantContext);
+
+        $order = new Order(Uuid::v4(), 'cust', Uuid::v4()->toRfc4122());
+        $user = new User('manager');
+        $token = $this->createConfiguredMock(TokenInterface::class, ['getUser' => $user]);
+        self::assertSame(OrderVoter::ACCESS_DENIED, $voter->vote($token, $order, ['order.view']));
+    }
+}
+

--- a/tests/Unit/Security/Voter/ProductVoterTest.php
+++ b/tests/Unit/Security/Voter/ProductVoterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security\Voter;
+
+use App\Domain\Catalog\Product;
+use App\Infrastructure\Security\Expression\ExpressionLanguageFactory;
+use App\Infrastructure\Security\PolicyEvaluator;
+use App\Infrastructure\Security\Voter\ProductVoter;
+use App\Shared\Feature\FeatureFlagService;
+use App\Shared\Tenant\TenantContext;
+use App\Shared\Tenant\TenantId;
+use App\Infrastructure\Security\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class ProductVoterTest extends TestCase
+{
+    private function evaluator(array $roles, TenantContext $tenantContext, bool $feature): PolicyEvaluator
+    {
+        $auth = new class($roles) implements AuthorizationCheckerInterface {
+            public function __construct(private array $roles) {}
+            public function isGranted($attribute, $subject = null): bool
+            {
+                return in_array($attribute, $this->roles, true);
+            }
+        };
+        $flags = new FeatureFlagService();
+        $flags->set(Uuid::fromString($tenantContext->get()->toString()), 'catalog_write', $feature);
+
+        return new PolicyEvaluator([
+            'order.view' => "is_granted('ROLE_MANAGER') or (user.id == subject.customerId)",
+            'product.write' => "is_granted('ROLE_MANAGER') and tenant(feature('catalog_write'))",
+        ], $auth, $tenantContext, $flags, new ExpressionLanguageFactory());
+    }
+
+    public function testRequiresManagerAndFeature(): void
+    {
+        $tenantId = new TenantId(Uuid::v4()->toRfc4122());
+        $tenantContext = new TenantContext($tenantId);
+        $evaluator = $this->evaluator(['ROLE_MANAGER'], $tenantContext, true);
+        $voter = new ProductVoter($evaluator, $tenantContext);
+        $product = new Product(Uuid::v4(), 's', 'n', 10, 'USD', $tenantId->toString());
+        $user = new User('manager');
+        $token = $this->createConfiguredMock(TokenInterface::class, ['getUser' => $user]);
+        self::assertSame(ProductVoter::ACCESS_GRANTED, $voter->vote($token, $product, ['product.write']));
+
+        $evaluator2 = $this->evaluator(['ROLE_MANAGER'], $tenantContext, false);
+        $voter2 = new ProductVoter($evaluator2, $tenantContext);
+        self::assertSame(ProductVoter::ACCESS_DENIED, $voter2->vote($token, $product, ['product.write']));
+    }
+
+    public function testCrossTenantDenied(): void
+    {
+        $tenantId = new TenantId(Uuid::v4()->toRfc4122());
+        $tenantContext = new TenantContext($tenantId);
+        $evaluator = $this->evaluator(['ROLE_MANAGER'], $tenantContext, true);
+        $voter = new ProductVoter($evaluator, $tenantContext);
+        $product = new Product(Uuid::v4(), 's', 'n', 10, 'USD', Uuid::v4()->toRfc4122());
+        $user = new User('manager');
+        $token = $this->createConfiguredMock(TokenInterface::class, ['getUser' => $user]);
+        self::assertSame(ProductVoter::ACCESS_DENIED, $voter->vote($token, $product, ['product.write']));
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce role hierarchy and declarative security policies
- add expression-based PolicyEvaluator with tenant and feature helpers
- wire voters and lightweight controllers for order and product security

## Testing
- `vendor/bin/phpunit` (fails: Invalid credentials)
- `vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run --diff` (fails: fixes needed)
- `vendor/bin/phpstan analyse -c phpstan.neon.dist` (fails: memory limit)


------
https://chatgpt.com/codex/tasks/task_e_68b2eb8c421083338e47de5cff0cc619